### PR TITLE
Failing actions

### DIFF
--- a/tests/src/Unit/ExampleTest.php
+++ b/tests/src/Unit/ExampleTest.php
@@ -14,8 +14,8 @@ class ExampleTest extends TestCase {
   /**
    * Asserts that universal laws are constant.
    */
-  public function testExample(): void {
-    $this->assertEquals(1, 1, "One equals one!");
+  public function testExample() {
+    $this->assertEquals(2,1, "One equals one!");
   }
 
 }


### PR DESCRIPTION
Removed spacing between parameters to fail PHPCS.
Removed return type for failing PHPStan.
Changed assertion to fail PHPUnit test.